### PR TITLE
fix a bug with 2.92

### DIFF
--- a/exercise/ex2-92.c
+++ b/exercise/ex2-92.c
@@ -23,5 +23,15 @@ float_bits float_negate(float_bits f)
 
         if (exp == 0xFF && frac != 0) /* NaN */
                 return f;
-        return (~sign << 31) | (exp << 23) | frac;
+    
+        unsigned reverseSign = ~sign
+        return reverseSign<<31 | (exp << 23) | frac;
+}
+
+
+
+int main(){
+    float_bits a = 0x81E00000;
+    float_bits result = float_negate(a);
+    printf("%x",result);
 }


### PR DESCRIPTION
修复了2.92中的一个bug，这里的符号位应该先取反再进行移位运算，否则低位会被污染。
